### PR TITLE
create kokoro/ folder with build scripts

### DIFF
--- a/kokoro/build.sh
+++ b/kokoro/build.sh
@@ -1,0 +1,39 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+# Fail on any error.
+set -e
+
+# Code under repo is checked out to this directory.
+cd "${KOKORO_ARTIFACTS_DIR}/github/dataflux-client-python"
+
+function install_requirements() {
+    echo Installing requirements.
+
+    echo Installing python3-pip.
+    sudo apt-get -y install python3-pip
+
+    echo Installing required dependencies.
+    pip install -r requirements.txt
+}
+
+function run_unit_tests() {
+    echo Running unit tests.
+    python -m pytest dataflux_core/tests --junit-xml="${KOKORO_ARTIFACTS_DIR}/unit_tests/sponge_log.xml"
+}
+
+install_requirements
+run_unit_tests

--- a/kokoro/continuous.cfg
+++ b/kokoro/continuous.cfg
@@ -1,0 +1,21 @@
+# Copyright 2024 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "dataflux-client-python/kokoro/build.sh"
+
+action {
+  define_artifacts {
+    regex: "**/unit_tests/sponge_log.xml"
+  }
+}

--- a/kokoro/presubmit.cfg
+++ b/kokoro/presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2024 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "dataflux-client-python/kokoro/build.sh"


### PR DESCRIPTION
Added Kokoro folders with build scripts.

The only difference between this and our previous GoB setup is the `cd` command that now it points to `../github/..` instead of `../git/..`.

Next: wait a few minutes and create a test PR.