### PR TITLE
added filter for storage class with default to standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This is the client library backing the [Dataflux Dataset for Pytorch](https://gi
 
 The fast list component of this client leverages Python multiprocessing to parallelize the listing of files within a GCS bucket. It does this by implementing a workstealing algorithm, where each worker in the list operation is able to steal work from its siblings once it has finished all currently slated listing work. This parallelization leads to a real world speed increase up to 10 times faster than sequential listing. Note that paralellization is limited by the machine on which the client runs, and optimal performance is typically found with a worker count that is 1:1 with the available cores. Benchmarking has demonstrated that the larger the object count, the better Dataflux performs when compared to a linear listing.
 
+#### Storage Class
+
+By default, fast list will only list objects of STANDARD class in GCS buckets. This can be overridden by passing in a string list of storage classes to include while running the Listing Controller. Note that this default behavior was chosen to avoid the cost associated with downloading non-standard GCS classes. Details on GCS Storage Classes can be further explored in the [Storage Class Documentation](https://cloud.google.com/storage/docs/storage-classes).
+
 ### Fast List Benchmark Results
 |File Count / Avg Size|VM Core Count|List Time Without Dataflux|List Time With Dataflux|
 |---------------------|-------------|--------------------------|-----------------------|

--- a/dataflux_core/tests/fake_gcs.py
+++ b/dataflux_core/tests/fake_gcs.py
@@ -56,8 +56,10 @@ class Bucket(object):
             self.blobs[name] = Blob(name, bucket=self)
         return self.blobs[name]
 
-    def _add_file(self, filename: str, content: bytes):
-        self.blobs[filename] = Blob(filename, content, self)
+    def _add_file(self, filename: str, content: bytes, storage_class="STANDARD"):
+        self.blobs[filename] = Blob(
+            filename, content, self, storage_class=storage_class
+        )
 
 
 class Blob(object):
@@ -71,12 +73,19 @@ class Blob(object):
         size: The size in bytes of the Blob.
     """
 
-    def __init__(self, name: str, content: bytes = b"", bucket: Bucket = None):
+    def __init__(
+        self,
+        name: str,
+        content: bytes = b"",
+        bucket: Bucket = None,
+        storage_class="STANDARD",
+    ):
         self.name = name
         self.retry = None
         self.content = content
         self.bucket = bucket
         self.size = len(self.content)
+        self.storage_class = storage_class
 
     def compose(self, sources: list[str], retry=None):
         b = b""


### PR DESCRIPTION
Adds a filter for storage class when listing objects. Default behavior is to only list STANDARD object type (no additional charges apply). This can be overridden by supplying a parameter.

> It's a good idea to open an issue first for discussion.

- [ X ] Tests pass
- [ X ] Appropriate changes to documentation are included in the PR