### PR TITLE
add threading functionality to dataflux

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Looking at the [download code](dataflux_core/download.py) you will notice three 
 
 ###### Parallel Download
 
-The `dataflux_download_parallel` function is the most performative stand-alone download function. When using the dataflux client library in isolation, this is the recommended download function. Parallelization must be tuned based on available CPU power and network bandwidth.
+The `dataflux_download_parallel` function is the most performant stand-alone download function. When using the dataflux client library in isolation, this is the recommended download function. Parallelization must be tuned based on available CPU power and network bandwidth.
 
 ###### Threaded Download
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ By default, fast list will only list objects of STANDARD class in GCS buckets. T
 
 The compose download component of the client uses the results of the fast list to efficiently download the files necessary for a machine learning workload. When downloading files from remote stores, small file size often bottlenecks the speed at which files can be downloaded. To avoid this bottleneck, compose download leverages the ability of GCS buckets to concatinate small files into larger composed files in GCS prior to downloading. This greatly improves download performance, particularly on datasets with very large numbers of small files.
 
+#### Multiple Download Options
+
+Looking at the [download code](dataflux_core/download.py) you will notice three distinct download functions. The default function used in the dataflux-pytorch client is `dataflux_download`. The other functions serve to improve performance for specific use cases.
+
+###### Parallel Download
+
+The `dataflux_download_parallel` function is the most performative stand-alone download function. When using the dataflux client library in isolation, this is the recommended download function. Parallelization must be tuned based on available CPU power and network bandwidth.
+
+###### Threaded Download
+
+The `dataflux_download_threaded` function allows for some amount of downlod parallelization while running within daemonic processes (e.g. a distributed ML workload leveraging [ray](https://www.ray.io/)). Daemonic processes are not permitted to spin up child processes, and thus threading must be used in these instances. Threading download performance is similar to that of multiprocessing for most use-cases, but loses out on performance as the thread/process count increases. Additionally, threading does not allow for signal interuption, so SIGINT cleanup triggers are disabled when running a threaded download.
+
 ## Getting Started
 
 To get started leveraging the dataflux client library, we encourage you to start from the [Dataflux Dataset for Pytorch](https://github.com/GoogleCloudPlatform/dataflux-pytorch). For an example of client-specific implementation, please see the [benchmark code](dataflux_core/benchmarking/dataflux_client_bench.py).

--- a/dataflux_core/benchmarking/dataflux_client_bench.py
+++ b/dataflux_core/benchmarking/dataflux_client_bench.py
@@ -14,7 +14,7 @@
  limitations under the License.
 
  Example benchmark execution:
- python3 fast_list_bench.py --project=test-project --bucket=test-bucket --bucket-file-count=5 --bucket-file-size=172635220 --num-workers=5 --max-compose=32
+ python3 dataflux_client_bench.py --project=test-project --bucket=test-bucket --bucket-file-count=5 --bucket-file-size=172635220 --num-workers=5 --max-compose=32
  """
 
 import argparse

--- a/dataflux_core/benchmarking/dataflux_client_parallel_bench.py
+++ b/dataflux_core/benchmarking/dataflux_client_parallel_bench.py
@@ -14,7 +14,7 @@
  limitations under the License.
 
  Example benchmark execution:
- python3 fast_list_bench.py --project=test-project --bucket=test-bucket --bucket-file-count=5 --bucket-file-size=172635220 --num-workers=5 --parallelization=30 --max-compose=32
+ python3 dataflux_client_parallel_bench.py --project=test-project --bucket=test-bucket --bucket-file-count=5 --bucket-file-size=172635220 --num-workers=5 --parallelization=30 --max-compose=32
  """
 
 import argparse

--- a/dataflux_core/benchmarking/dataflux_client_threaded_bench.py
+++ b/dataflux_core/benchmarking/dataflux_client_threaded_bench.py
@@ -1,0 +1,77 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ Example benchmark execution:
+ python3 fast_list_bench.py --project=test-project --bucket=test-bucket --bucket-file-count=5 --bucket-file-size=172635220 --num-workers=5 --threads=30 --max-compose=32
+ """
+
+import argparse
+import time
+from dataflux_core import fast_list, download
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", type=str)
+    parser.add_argument("--bucket", type=str)
+    parser.add_argument("--bucket-file-count", type=int, default=None)
+    parser.add_argument("--bucket-file-size", type=int, default=None)
+    parser.add_argument("--num-workers", type=int, default=10)
+    parser.add_argument("--max-compose-bytes", type=int, default=100000000)
+    parser.add_argument("--threads", type=int, default=20)
+    parser.add_argument("--prefix", type=str, default=None)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    list_start_time = time.time()
+    print(f"Listing operation started at {list_start_time}")
+    list_result = fast_list.ListingController(
+        args.num_workers, args.project, args.bucket, prefix=args.prefix
+    ).run()
+    list_end_time = time.time()
+    if args.bucket_file_count and len(list_result) != args.bucket_file_count:
+        raise AssertionError(
+            f"Expected {args.bucket_file_count} files, but got {len(list_result)}"
+        )
+    print(
+        f"{len(list_result)} objects listed in {list_end_time - list_start_time} seconds"
+    )
+    download_params = download.DataFluxDownloadOptimizationParams(
+        args.max_compose_bytes
+    )
+    download_start_time = time.time()
+    print(f"Download operation started at {download_start_time}")
+    download_result = download.dataflux_download_threaded(
+        args.project,
+        args.bucket,
+        list_result,
+        dataflux_download_optimization_params=download_params,
+        threads=args.threads,
+    )
+    download_end_time = time.time()
+    total_size = sum([len(x) for x in download_result])
+    if args.bucket_file_size and total_size != args.bucket_file_size:
+        raise AssertionError(
+            f"Expected {args.bucket_file_size} bytes but got {total_size} bytes"
+        )
+    print(
+        f"{total_size} bytes across {len(list_result)} objects downloaded in {download_end_time - download_start_time} seconds using {args.threads} processes"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dataflux_core/benchmarking/dataflux_client_threaded_bench.py
+++ b/dataflux_core/benchmarking/dataflux_client_threaded_bench.py
@@ -69,7 +69,7 @@ def main() -> None:
             f"Expected {args.bucket_file_size} bytes but got {total_size} bytes"
         )
     print(
-        f"{total_size} bytes across {len(list_result)} objects downloaded in {download_end_time - download_start_time} seconds using {args.threads} processes"
+        f"{total_size} bytes across {len(list_result)} objects downloaded in {download_end_time - download_start_time} seconds using {args.threads} threads"
     )
 
 

--- a/dataflux_core/benchmarking/dataflux_client_threaded_bench.py
+++ b/dataflux_core/benchmarking/dataflux_client_threaded_bench.py
@@ -14,7 +14,7 @@
  limitations under the License.
 
  Example benchmark execution:
- python3 fast_list_bench.py --project=test-project --bucket=test-bucket --bucket-file-count=5 --bucket-file-size=172635220 --num-workers=5 --threads=30 --max-compose=32
+ python3 dataflux_client_threaded_bench.py --project=test-project --bucket=test-bucket --bucket-file-count=5 --bucket-file-size=172635220 --num-workers=5 --threads=30 --max-compose=32
  """
 
 import argparse


### PR DESCRIPTION
Parallel processes are not functional with daemonic workers, so threading must be used to integrate download parallelization with real ML workloads. When running on an already-distributed system (e.g. executing with Ray or DLIO managing parallelization) the daemons executing each portion of the training will not allow further sub-processes to be spun up.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR