### PR TITLE
Add support for lazy dataflux download

### DIFF
--- a/dataflux_core/download.py
+++ b/dataflux_core/download.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from google.cloud import storage
 from google.cloud.storage.retry import DEFAULT_RETRY
+from google.api_core.client_info import ClientInfo
 
 import uuid
 import logging
@@ -72,7 +73,10 @@ def compose(
         )
 
     if storage_client is None:
-        storage_client = storage.Client(project=project_name)
+        storage_client = storage.Client(
+            project=project_name,
+            client_info=ClientInfo(user_agent="dataflux/0.0"),
+        )
 
     bucket = storage_client.bucket(bucket_name)
     destination = bucket.blob(destination_blob_name)
@@ -110,7 +114,10 @@ def decompose(
         the contents (in bytes) of the decomposed objects.
     """
     if storage_client is None:
-        storage_client = storage.Client(project=project_name)
+        storage_client = storage.Client(
+            project=project_name,
+            client_info=ClientInfo(user_agent="dataflux/0.0"),
+        )
 
     res = []
     composed_object_content = download_single(
@@ -318,7 +325,10 @@ def dataflux_download(
         the contents of the object in bytes.
     """
     if storage_client is None:
-        storage_client = storage.Client(project=project_name)
+        storage_client = storage.Client(
+            project=project_name,
+            client_info=ClientInfo(user_agent="dataflux/0.0"),
+        )
 
     res = []
     max_composite_object_size = (
@@ -420,7 +430,10 @@ def dataflux_download_lazy(
         An iterator of the contents of the object in bytes.
     """
     if storage_client is None:
-        storage_client = storage.Client(project=project_name)
+        storage_client = storage.Client(
+            project=project_name,
+            client_info=ClientInfo(user_agent="dataflux/0.0"),
+        )
 
     max_composite_object_size = (
         dataflux_download_optimization_params.max_composite_object_size


### PR DESCRIPTION
Added support for "lazy" Dataflux download using the Python Generator pattern.

This is similar to the `dataflux_download` function with slight differences on "returning" the results. Here we use "yield from" to lazily compute and return.

This is needed for Dataflux iterable dataset where each worker will now be responsible for downloading a portion of the entire dataset. For example, suppose that users initialize a `DataFluxIterableStyleDataset` on a dataset of 10000 objects. Then users pass that dataset into the PyTorch DataLoader with `num_workers=4`, then each worker will be responsible for downloading the 2500 objects. We will not want to download the whole 2500 objects all at once and then yield one after another. See more in the [design doc](https://docs.google.com/document/d/1SrodotAH7Z2QG6Lx-PZmCRRp4bC2u_U_58TmBjIDRz8/edit?resourcekey=0-4-2exqxutJbVrmSwD3LGyg&tab=t.0#heading=h.hakufr96ezb).

Tested by adding the unit test and running `python3 -m pytest dataflux_core/tests`. Found a flaky test into a bug that I filed internally.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR