### PR TITLE
Stabilize threads

### DIFF
--- a/dataflux_core/download.py
+++ b/dataflux_core/download.py
@@ -232,13 +232,13 @@ def dataflux_download_threaded(
         chunk = objects[i * chunk_size : (i + 1) * chunk_size]
         if chunk:
             chunks.append(chunk)
-    results_queue = queue.Queue()
+    results_queues = [queue.Queue() for _ in chunks]
     thread_list = []
-    for chunk in chunks:
+    for i, chunk in enumerate(chunks):
         thread = threading.Thread(
             target=df_download_thread,
             args=(
-                results_queue,
+                results_queues[i],
                 project_name,
                 bucket_name,
                 chunk,
@@ -251,8 +251,9 @@ def dataflux_download_threaded(
     for thread in thread_list:
         thread.join()
     results = []
-    while not results_queue.empty():
-        results.extend(results_queue.get())
+    for q in results_queues:
+        while not q.empty():
+            results.extend(q.get())
     return results
 
 

--- a/dataflux_core/tests/test_fast_list.py
+++ b/dataflux_core/tests/test_fast_list.py
@@ -92,7 +92,8 @@ class FastListTest(unittest.TestCase):
                 "directory_obj_count": 10,
                 "skip_compose": True,
                 "list_directory_objects": True,
-                "expected_objects": 10010,
+                # This should now fail
+                "expected_objects": 100101,
                 "expected_api_calls": 3,
             },
             {

--- a/dataflux_core/tests/test_fast_list.py
+++ b/dataflux_core/tests/test_fast_list.py
@@ -92,7 +92,7 @@ class FastListTest(unittest.TestCase):
                 "directory_obj_count": 10,
                 "skip_compose": True,
                 "list_directory_objects": True,
-                "expected_objects": 1001000,
+                "expected_objects": 10010,
                 "expected_api_calls": 3,
             },
             {

--- a/dataflux_core/tests/test_fast_list.py
+++ b/dataflux_core/tests/test_fast_list.py
@@ -92,8 +92,7 @@ class FastListTest(unittest.TestCase):
                 "directory_obj_count": 10,
                 "skip_compose": True,
                 "list_directory_objects": True,
-                # This should now fail
-                "expected_objects": 100101,
+                "expected_objects": 10010,
                 "expected_api_calls": 3,
             },
             {

--- a/dataflux_core/tests/test_fast_list.py
+++ b/dataflux_core/tests/test_fast_list.py
@@ -92,7 +92,7 @@ class FastListTest(unittest.TestCase):
                 "directory_obj_count": 10,
                 "skip_compose": True,
                 "list_directory_objects": True,
-                "expected_objects": 10010,
+                "expected_objects": 1001000,
                 "expected_api_calls": 3,
             },
             {


### PR DESCRIPTION
Addresses issue where threaded download would not maintain ordering of objects listed from the bucket.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR