### PR TITLE
add support for clean test output

### DIFF
--- a/kokoro/presubmit.cfg
+++ b/kokoro/presubmit.cfg
@@ -13,3 +13,9 @@
 # limitations under the License.
 
 build_file: "dataflux-client-python/kokoro/build.sh"
+
+action {
+  define_artifacts {
+    regex: "**/unit_tests/sponge_log.xml"
+  }
+}


### PR DESCRIPTION
Add config so that per-test output is cleaner for presubmits.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR