### PR TITLE
Debug logging for Kokoro unit test build

### DIFF
--- a/kokoro/build.sh
+++ b/kokoro/build.sh
@@ -32,7 +32,7 @@ function install_requirements() {
 
 function run_unit_tests() {
     echo Running unit tests.
-    python -m pytest dataflux_core/tests --junit-xml="${KOKORO_ARTIFACTS_DIR}/unit_tests/sponge_log.xml"
+    python -m pytest dataflux_core/tests --junit-xml="${KOKORO_ARTIFACTS_DIR}/unit_tests/sponge_log.xml" --log-cli-level=DEBUG
 }
 
 install_requirements


### PR DESCRIPTION
This will make the logs more informative when debugging test failures on Kokoro.

This was used in https://github.com/GoogleCloudPlatform/dataflux-client-python/pull/31 to help understand why tests were failing on JD's PR despite passing locally. 

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR