### PR TITLE
update call to use python3

### DIFF
--- a/kokoro/hourly.sh
+++ b/kokoro/hourly.sh
@@ -32,7 +32,7 @@ function install_requirements() {
 
 function run_hourly_tests() {
     echo Running performance tests.
-    python dataflux_core/performance_tests/list_only.py --project=$PROJECT --bucket=$BUCKET --bucket-file-count=500000 --num-workers=4 --prefix=$PREFIX
+    python3 dataflux_core/performance_tests/list_only.py --project=$PROJECT --bucket=$BUCKET --bucket-file-count=500000 --num-workers=32 --prefix=$PREFIX
 }
 
 install_requirements


### PR DESCRIPTION
Update call to specify python3 to avoid internal errors with custom machine execution.


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR