### PR TITLE
update testing to support segmented download for large filesets

### DIFF
--- a/dataflux_core/performance_tests/list_and_download.py
+++ b/dataflux_core/performance_tests/list_and_download.py
@@ -18,63 +18,120 @@ import unittest
 import time
 import os
 from dataflux_core import fast_list, download
+from math import ceil
+
+FIFTY_GB = 50000000000
 
 
 class ClientPerformanceTest(unittest.TestCase):
-    def test_list_and_download(self):
-        # Gather Environment Variables.
-        project = os.getenv("PROJECT")
-        bucket = os.getenv("BUCKET")
-        prefix = os.getenv("PREFIX")
-        num_workers = os.getenv("LIST_WORKERS")
-        expected_file_count = os.getenv("FILE_COUNT")
-        expected_file_size = os.getenv("TOTAL_FILE_SIZE")
-        max_compose_bytes = os.getenv("MAX_COMPOSE_BYTES")
-        list_timeout = os.getenv("LIST_TIMEOUT")
-        download_timeout = os.getenv("DOWNLOAD_TIMEOUT")
+    def get_config(self):
+        config = {}
+        # Gather env vars into dictionary.
+        config["project"] = os.getenv("PROJECT")
+        config["bucket"] = os.getenv("BUCKET")
+        config["prefix"] = os.getenv("PREFIX")
+        config["num_workers"] = os.getenv("LIST_WORKERS")
+        config["expected_file_count"] = os.getenv("FILE_COUNT")
+        config["expected_total_size"] = os.getenv("TOTAL_FILE_SIZE")
+        config["max_compose_bytes"] = os.getenv("MAX_COMPOSE_BYTES")
+        config["list_timeout"] = os.getenv("LIST_TIMEOUT")
+        config["download_timeout"] = os.getenv("DOWNLOAD_TIMEOUT")
+        config["parallelization"] = os.getenv("PARALLELIZATION")
 
         # Type convert env vars.
-        if num_workers:
-            num_workers = int(num_workers)
-        if expected_file_count:
-            expected_file_count = int(expected_file_count)
-        if expected_file_size:
-            expected_file_size = int(expected_file_size)
-        max_compose_bytes = int(max_compose_bytes) if max_compose_bytes else 100000000
-        if list_timeout:
-            list_timeout = float(list_timeout)
-        if download_timeout:
-            download_timeout = float(download_timeout)
+        if config["num_workers"]:
+            config["num_workers"] = int(config["num_workers"])
+        if config["expected_file_count"]:
+            config["expected_file_count"] = int(config["expected_file_count"])
+        if config["expected_total_size"]:
+            config["expected_total_size"] = int(config["expected_total_size"])
+        config["max_compose_bytes"] = (
+            int(config["max_compose_bytes"])
+            if config["max_compose_bytes"]
+            else 100000000
+        )
+        if config["list_timeout"]:
+            config["list_timeout"] = float(config["list_timeout"])
+        if config["download_timeout"]:
+            config["download_timeout"] = float(config["download_timeout"])
+        config["parallelization"] = (
+            int(config["parallelization"]) if config["parallelization"] else 1
+        )
+
+        return config
+
+    def run_list(self, config):
         list_start_time = time.time()
         list_result = fast_list.ListingController(
-            num_workers, project, bucket, prefix=prefix
+            config["num_workers"],
+            config["project"],
+            config["bucket"],
+            prefix=config["prefix"],
         ).run()
         list_end_time = time.time()
         listing_time = list_end_time - list_start_time
-        if expected_file_count and len(list_result) != expected_file_count:
+        if (
+            config["expected_file_count"]
+            and len(list_result) != config["expected_file_count"]
+        ):
             raise AssertionError(
-                f"Expected {expected_file_count} files, but got {len(list_result)}"
+                f"Expected {config['expected_file_count']} files, but got {len(list_result)}"
             )
-        if list_timeout and listing_time > list_timeout:
+        if config["list_timeout"] and listing_time > config["list_timeout"]:
             raise AssertionError(
-                f"Expected list operation to complete in under {list_timeout} seconds, but took {listing_time} seconds."
+                f"Expected list operation to complete in under {config['list_timeout']} seconds, but took {listing_time} seconds."
             )
-        download_params = download.DataFluxDownloadOptimizationParams(max_compose_bytes)
-        download_start_time = time.time()
-        download_result = download.dataflux_download(
-            project,
-            bucket,
-            list_result,
-            dataflux_download_optimization_params=download_params,
+        return list_result
+
+    def run_download(self, config, list_result):
+        download_params = download.DataFluxDownloadOptimizationParams(
+            config["max_compose_bytes"]
         )
+        download_start_time = time.time()
+        download_result = None
+        if config["parallelization"] and config["parallelization"] > 1:
+            download_result = download.dataflux_download_parallel(
+                config["project"],
+                config["bucket"],
+                list_result,
+                dataflux_download_optimization_params=download_params,
+                parallelization=config["parallelization"],
+            )
+        else:
+            download_result = download.dataflux_download(
+                config["project"],
+                config["bucket"],
+                list_result,
+                dataflux_download_optimization_params=download_params,
+            )
         download_end_time = time.time()
         downloading_time = download_end_time - download_start_time
         total_size = sum([len(x) for x in download_result])
-        if expected_file_size and total_size != expected_file_size:
+        if (
+            config["expected_total_size"]
+            and total_size != config["expected_total_size"]
+        ):
             raise AssertionError(
-                f"Expected {expected_file_size} bytes but got {total_size} bytes"
+                f"Expected {config['expected_total_size']} bytes but got {total_size} bytes"
             )
-        if download_timeout and downloading_time > download_timeout:
+        if config["download_timeout"] and downloading_time > config["download_timeout"]:
             raise AssertionError(
-                f"Expected download operation to complete in under {download_timeout} seconds, but took {downloading_time} seconds."
+                f"Expected download operation to complete in under {config['download_timeout']} seconds, but took {downloading_time} seconds."
             )
+
+    def test_list_and_download_one_shot(self):
+        config = self.get_config()
+        list_result = self.run_list(config)
+        self.run_download(config, list_result)
+
+    def test_list_and_download_segmented(self):
+        config = self.get_config()
+        list_result = self.run_list(config)
+        num_segments = config["expected_total_size"] / FIFTY_GB
+        segment_size = ceil(config["expected_file_count"] / num_segments)
+        segments = [
+            list_result[i : i + segment_size]
+            for i in range(0, len(list_result), segment_size)
+        ]
+        for seg in segments:
+            self.run_download(config, list_result)

--- a/dataflux_core/performance_tests/list_and_download.py
+++ b/dataflux_core/performance_tests/list_and_download.py
@@ -125,6 +125,8 @@ class ClientPerformanceTest(unittest.TestCase):
         self.run_download(config, list_result)
 
     def test_list_and_download_segmented(self):
+        # This function is needed to avoid OOM errors when the dataset size
+        # exceeds the memory of the VM.
         config = self.get_config()
         list_result = self.run_list(config)
         num_segments = config["expected_total_size"] / FIFTY_GB

--- a/kokoro/hourly.sh
+++ b/kokoro/hourly.sh
@@ -35,6 +35,9 @@ function install_requirements() {
 
 function run_hourly_tests() {
     echo Running performance tests.
+    # -k one_shot triggers a full list and download, loading all files into memory in one shot.
+    # Alternatively, the segmented test allows us to divide the download into multiple passes
+    # to avoid OOM errors.
     python3 -m pytest dataflux_core/performance_tests/list_and_download.py -k one_shot -vv --junit-xml="${KOKORO_ARTIFACTS_DIR}/unit_tests/sponge_log.xml" --log-cli-level=DEBUG
 }
 

--- a/kokoro/hourly.sh
+++ b/kokoro/hourly.sh
@@ -35,7 +35,7 @@ function install_requirements() {
 
 function run_hourly_tests() {
     echo Running performance tests.
-    python3 -m pytest dataflux_core/performance_tests/list_and_download.py -vv --junit-xml="${KOKORO_ARTIFACTS_DIR}/unit_tests/sponge_log.xml" --log-cli-level=DEBUG
+    python3 -m pytest dataflux_core/performance_tests/list_and_download.py -k one_shot -vv --junit-xml="${KOKORO_ARTIFACTS_DIR}/unit_tests/sponge_log.xml" --log-cli-level=DEBUG
 }
 
 install_requirements


### PR DESCRIPTION
Refactor performance tests so that it can support segmented download (in 50GB chunks). This function is not used in this CL, but will be triggered for longer 750GB nightly performance testing to be added in followup CL. Splitting of CLs is to allow for easy rollback in case of nightly test failure.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR