### PR TITLE
update to use parallel download for nightly test

### DIFF
--- a/kokoro/nightly.cfg
+++ b/kokoro/nightly.cfg
@@ -59,6 +59,11 @@ env_vars {
   value: "14400"
 }
 
+env_vars {
+  key: "PARALLELIZATION"
+  value: "32"
+}
+
 action {
   define_artifacts {
     regex: "**/unit_tests/sponge_log.xml"


### PR DESCRIPTION
Update the nightly test to parallelize its download.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR