### PR TITLE
update segmented func to correctly list only segments

### DIFF
--- a/dataflux_core/performance_tests/list_and_download.py
+++ b/dataflux_core/performance_tests/list_and_download.py
@@ -136,4 +136,4 @@ class ClientPerformanceTest(unittest.TestCase):
             for i in range(0, len(list_result), segment_size)
         ]
         for seg in segments:
-            self.run_download(config, list_result)
+            self.run_download(config, seg)


### PR DESCRIPTION
Nightly test was not correctly segmenting its download, causing it to OOM after a certain duration.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR