### PR TITLE
increase backoff deadline and maximum backoff

### DIFF
--- a/dataflux_core/download.py
+++ b/dataflux_core/download.py
@@ -33,8 +33,9 @@ import signal
 import sys
 
 # https://cloud.google.com/storage/docs/retry-strategy#python.
-MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(300.0).with_delay(
-    initial=1.0, multiplier=1.2, maximum=45.0
+# 15 minute deadline with maximum delay of 2.5 minutes.
+MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(900.0).with_delay(
+    initial=1.0, multiplier=1.2, maximum=150.0
 )
 
 # https://cloud.google.com/storage/docs/composite-objects.


### PR DESCRIPTION
This change is aimed at addressing rate limiting errors seen during 1000 node cluster testing. Further confirmation is required to confirm this change addresses the issue at scale.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR