### PR TITLE
Allowed for FakeBlobWriter to be used as context manager

### DIFF
--- a/dataflux_core/tests/fake_gcs.py
+++ b/dataflux_core/tests/fake_gcs.py
@@ -69,6 +69,10 @@ class FakeBlobWriter(object):
         self.blob.content += data
     def flush(self):
         pass
+    def __enter__(self):
+        pass
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
 
 class Blob(object):
     """Blob represents a GCS blob object.


### PR DESCRIPTION
Added enter and exit functions to FakeBlobWriter

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR