### PR TITLE
support configurable retry parameters for fast_list and download

### DIFF
--- a/dataflux_core/download.py
+++ b/dataflux_core/download.py
@@ -316,9 +316,7 @@ def dataflux_download(
     storage_client: object = None,
     dataflux_download_optimization_params: DataFluxDownloadOptimizationParams = None,
     threading_enabled=False,
-    retry_factor: float = 1.2,
-    retry_max: float = 60,
-    retry_deadline: float = 300,
+    retry_config=MODIFIED_RETRY,
 ) -> list[bytes]:
     """Perform the DataFlux download algorithm to download the object contents as bytes and return.
 
@@ -331,15 +329,10 @@ def dataflux_download(
         storage_client: the google.cloud.storage.Client initialized with the project.
             If not defined, the function will initialize the client with the project_name.
         dataflux_download_optimization_params: the paramemters used to optimize the download performance.
-        retry_factor: The multiplicative increase in retry wait time per retry.
-        retry_max: The maximum wait time between download, compose, or delete call retry.
-        retry_deadline: The deadline for ending a retry effort.
+        retry_config: The retry configuration to pass to all retryable download operations
     Returns:
         the contents of the object in bytes.
     """
-    retry_config = DEFAULT_RETRY.with_deadline(retry_deadline).with_delay(
-        initial=1.0, multiplier=retry_factor, maximum=retry_max
-    )
     if storage_client is None:
         storage_client = storage.Client(
             project=project_name,
@@ -430,9 +423,7 @@ def dataflux_download_lazy(
     storage_client: object = None,
     dataflux_download_optimization_params: DataFluxDownloadOptimizationParams = None,
     threading_enabled=False,
-    retry_factor: float = 1.2,
-    retry_max: float = 60,
-    retry_deadline: float = 300,
+    retry_config: "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
 ) -> Iterator[bytes]:
     """Perform the DataFlux download algorithm to download the object contents as bytes in a lazy fashion.
 
@@ -445,15 +436,10 @@ def dataflux_download_lazy(
         storage_client: the google.cloud.storage.Client initialized with the project.
             If not defined, the function will initialize the client with the project_name.
         dataflux_download_optimization_params: the paramemters used to optimize the download performance.
-        retry_factor: The multiplicative increase in retry wait time for each retry.
-        retry_max: The maximum wait time per download, compose, or delete call retry.
-        retry_deadline: The deadline for ending a download retry effort.
+        retry_config: The retry parameter to supply to the compose objects call.
     Returns:
         An iterator of the contents of the object in bytes.
     """
-    retry_config = DEFAULT_RETRY.with_deadline(retry_deadline).with_delay(
-        initial=1.0, multiplier=retry_factor, maximum=retry_max
-    )
     if storage_client is None:
         storage_client = storage.Client(
             project=project_name,

--- a/dataflux_core/fast_list.py
+++ b/dataflux_core/fast_list.py
@@ -326,9 +326,7 @@ class ListingController(object):
         skip_compose: When true, skip listing files with the composed object prefix.
         prefix: When provided, only list objects under this prefix.
         allowed_storage_classes: The set of GCS Storage Class types fast list will include.
-        retry_factor: The multiplicative increase in retry wait time for each retry.
-        retry_max: The maximum wait time per list call retry.
-        retry_deadline: The deadline for ending a list retry effort.
+        retry_config: The retry config passed to list_blobs.
     """
 
     def __init__(
@@ -340,9 +338,7 @@ class ListingController(object):
         skip_compose: bool = True,
         prefix: str = "",
         allowed_storage_classes: list[str] = DEFAULT_ALLOWED_CLASS,
-        retry_factor: float = 1.2,
-        retry_max: float = 60,
-        retry_deadline: float = 300,
+        retry_config=MODIFIED_RETRY,
     ):
         # The maximum number of threads utilized in the fast list operation.
         self.max_parallelism = max_parallelism
@@ -356,9 +352,7 @@ class ListingController(object):
         self.skip_compose = skip_compose
         self.prefix = prefix
         self.allowed_storage_classes = allowed_storage_classes
-        self.retry_config = DEFAULT_RETRY.with_deadline(retry_deadline).with_delay(
-            initial=1.0, multiplier=retry_factor, maximum=retry_max
-        )
+        self.retry_config = retry_config
 
     def manage_tracking_queues(
         self,

--- a/dataflux_core/fast_list.py
+++ b/dataflux_core/fast_list.py
@@ -24,9 +24,13 @@ import logging
 import time
 
 from google.cloud import storage
+from google.cloud.storage.retry import DEFAULT_RETRY
 from google.api_core.client_info import ClientInfo
 
 DEFAULT_ALLOWED_CLASS = ["STANDARD"]
+MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(300.0).with_delay(
+    initial=1.0, multiplier=1.2, maximum=45.0
+)
 
 
 def remove_prefix(text: str, prefix: str):
@@ -61,6 +65,7 @@ class ListWorker(object):
         metadata_queue: Multiprocessing queue on which the worker pushes tracking metadata.
         start_range: Stirng start range worker will begin listing from.
         end_range: String end range worker will list until.
+        retry_config: The retry parameter to supply to list_blob.
 
         results: Set storing aggregate results prior to pushing onto results_queue.
         client: The GCS client through which all GCS list operations are executed.
@@ -88,6 +93,7 @@ class ListWorker(object):
         metadata_queue: "multiprocessing.Queue[tuple[str, int]]",
         start_range: str,
         end_range: str,
+        retry_config: "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
         client: storage.Client = None,
         skip_compose: bool = True,
         list_directory_objects: bool = False,
@@ -118,6 +124,7 @@ class ListWorker(object):
         self.allowed_storage_classes = allowed_storage_classes
         self.api_call_count = 0
         self.max_retries = max_retries
+        self.retry_config = retry_config
 
     def wait_for_work(self) -> bool:
         """Indefinitely waits for available work and consumes it once available.
@@ -183,6 +190,7 @@ class ListWorker(object):
                     "end_offset": (
                         "" if not self.end_range else self.prefix + self.end_range
                     ),
+                    "retry": self.retry_config,
                 }
                 if self.prefix:
                     list_blob_args["prefix"] = self.prefix
@@ -256,6 +264,7 @@ def run_list_worker(
     metadata_queue: "multiprocessing.Queue[tuple[str, int]]",
     start_range: str,
     end_range: str,
+    retry_config: "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
     client: storage.Client = None,
     skip_compose: bool = True,
     prefix: str = "",
@@ -276,6 +285,7 @@ def run_list_worker(
       metadata_queue: Multiprocessing queue on which the worker pushes tracking metadata.
       start_range: String start range worker will begin listing from.
       end_range: String end range worker will list until.
+      retry_config: The retry parameter to supply to list_blob.
       client: The GCS storage client. When not provided, will be derived from background auth.
       skip_compose: When true, skip listing files with the composed object prefix.
       prefix: When provided, only list objects under this prefix.
@@ -294,6 +304,7 @@ def run_list_worker(
         metadata_queue,
         start_range,
         end_range,
+        retry_config,
         client,
         skip_compose=skip_compose,
         prefix=prefix,
@@ -315,6 +326,9 @@ class ListingController(object):
         skip_compose: When true, skip listing files with the composed object prefix.
         prefix: When provided, only list objects under this prefix.
         allowed_storage_classes: The set of GCS Storage Class types fast list will include.
+        retry_factor: The multiplicative increase in retry wait time for each retry.
+        retry_max: The maximum wait time per list call retry.
+        retry_deadline: The deadline for ending a list retry effort.
     """
 
     def __init__(
@@ -326,6 +340,9 @@ class ListingController(object):
         skip_compose: bool = True,
         prefix: str = "",
         allowed_storage_classes: list[str] = DEFAULT_ALLOWED_CLASS,
+        retry_factor: float = 1.2,
+        retry_max: float = 60,
+        retry_deadline: float = 300,
     ):
         # The maximum number of threads utilized in the fast list operation.
         self.max_parallelism = max_parallelism
@@ -339,6 +356,9 @@ class ListingController(object):
         self.skip_compose = skip_compose
         self.prefix = prefix
         self.allowed_storage_classes = allowed_storage_classes
+        self.retry_config = DEFAULT_RETRY.with_deadline(retry_deadline).with_delay(
+            initial=1.0, multiplier=retry_factor, maximum=retry_max
+        )
 
     def manage_tracking_queues(
         self,
@@ -466,7 +486,9 @@ class ListingController(object):
         """
         for p in processes:
             p.terminate()
-        raise RuntimeError("multiprocessing child process became unresponsive; check logs for underlying error")
+        raise RuntimeError(
+            "multiprocessing child process became unresponsive; check logs for underlying error"
+        )
 
     def run(self) -> list[tuple[str, int]]:
         """Runs the controller that manages fast listing.
@@ -507,6 +529,7 @@ class ListingController(object):
                     metadata_queue,
                     "" if i == 0 else None,
                     "" if i == 0 else None,
+                    self.retry_config,
                     self.client,
                     self.skip_compose,
                     self.prefix,

--- a/dataflux_core/tests/fake_gcs.py
+++ b/dataflux_core/tests/fake_gcs.py
@@ -24,6 +24,7 @@ server, which could be a future improvement.
 from __future__ import annotations
 import io
 
+
 class Bucket(object):
     """Bucket represents a bucket in GCS, containing objects."""
 
@@ -39,6 +40,7 @@ class Bucket(object):
         start_offset: str = "",
         end_offset: str = "",
         prefix: str = "",
+        retry: "google.api_core.retry.retry_unary.Retry" = None,
     ) -> list[Blob]:
         results = []
         for name in sorted(self.blobs):
@@ -61,18 +63,25 @@ class Bucket(object):
             filename, content, self, storage_class=storage_class
         )
 
+
 class FakeBlobWriter(object):
     """Represents fake BlobWriter."""
+
     def __init__(self, blob):
         self.blob = blob
-    def write(self, data:bytes):
+
+    def write(self, data: bytes):
         self.blob.content += data
+
     def flush(self):
         pass
+
     def __enter__(self):
         pass
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
+
 
 class Blob(object):
     """Blob represents a GCS blob object.
@@ -116,11 +125,10 @@ class Blob(object):
         if mode == "rb":
             return io.BytesIO(self.content)
         elif mode == "wb":
-            self.content = b''
+            self.content = b""
             return FakeBlobWriter(self)
-        raise NotImplementedError(
-            "Supported modes strings are 'rb' and 'wb' only."
-        )
+        raise NotImplementedError("Supported modes strings are 'rb' and 'wb' only.")
+
 
 class Client(object):
     """Client represents a GCS client which can provide bucket handles."""


### PR DESCRIPTION
Include retry configuration for fast list, and allow user configuration. Employs use of default to avoid breaking legacy usage.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR