### PR TITLE
Raise exception when a child process fails.

### DIFF
--- a/dataflux_core/tests/test_fast_list.py
+++ b/dataflux_core/tests/test_fast_list.py
@@ -147,6 +147,7 @@ class FastListTest(unittest.TestCase):
                 queue.Queue(),
                 results_queue,
                 metadata_queue,
+                queue.Queue(),
                 "",
                 "",
                 skip_compose=tc["skip_compose"],
@@ -276,6 +277,17 @@ class FastListTest(unittest.TestCase):
             self.fail(
                 f"got {got_total_size} results, want {object_count * object_size}"
             )
+    
+    def test_list_controller_e2e_error(self):
+        """Full end to end test of the fast list operation with one worker which exits with an error."""
+        client = fake_gcs.Client()
+        controller = fast_list.ListingController(1, "", "", True)
+        controller.client = client
+        try:
+            results = controller.run()
+        except:
+            return
+        self.fail("Expected controller to raise an error when child process raises an error but it did not")
 
     def test_wait_for_work_success(self):
         """Tests waiting for work when there is still work remaining."""
@@ -302,6 +314,7 @@ class FastListTest(unittest.TestCase):
             unidle_queue,
             results_queue,
             metadata_queue,
+            queue.Queue(),
             "",
             "",
         )
@@ -341,6 +354,7 @@ class FastListTest(unittest.TestCase):
             unidle_queue,
             results_queue,
             metadata_queue,
+            queue.Queue(),
             "",
             "",
         )
@@ -373,6 +387,7 @@ class FastListTest(unittest.TestCase):
             queue.Queue(),
             results_queue,
             metadata_queue,
+            queue.Queue(),
             "",
             "",
         )


### PR DESCRIPTION
This will make sure that we crash when listing gets an error, rather than returning 0 results or partial results.

This fixes cases in logs like this:

```
ERROR 2024-05-29T20:24:50.742559314Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] + echo 'running the training code'
INFO 2024-05-29T20:24:50.742565326Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] running the training code
ERROR 2024-05-29T20:24:50.743228320Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] + python3 /app/list_and_download.py --project=gcs-tess --bucket=tessellations-datasets --prefix=UNet3D/medium/3MB-150GB --sleep-per-step=0 --num-workers=32 --prefetch-factor=2
INFO 2024-05-29T20:24:57.405772597Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Listing started at time 1717014292.3379545
INFO 2024-05-29T20:25:01.154942927Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Listing discovered 0 objects in 8.813388109207153 seconds.
INFO 2024-05-29T20:25:01.154975334Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Training started at time 1717014301.1524167
INFO 2024-05-29T20:25:01.625301578Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 0 took 0.3598899841308594 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625332822Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 1 took 0.010749578475952148 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625336387Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 2 took 0.009763002395629883 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625339249Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 3 took 0.009918451309204102 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625341642Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 4 took 0.009438276290893555 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625344047Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 5 took 0.00977015495300293 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625346479Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 6 took 0.010241985321044922 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625354517Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 7 took 0.010034561157226562 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625357951Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 8 took 0.009358882904052734 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625360609Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] Epoch 9 took 0.009837865829467773 seconds to iterate over 0 objects and 0 bytes.
INFO 2024-05-29T20:25:01.625363374Z [resource.labels.containerName: dataflux-list-and-download-sha256-1] All training (10 epochs) took 0.4491462707519531 seconds.
Update: Getting better logs now, possibly because I set the log level in my list-and-download binary:


No newer entries found matching current filter.
2024-06-05 19:32:40.265 PDT
+ echo 'running the training code'
2024-06-05 19:32:40.265 PDT
running the training code
2024-06-05 19:32:40.265 PDT
+ python3 -u /app/list_and_download.py --project=gcs-tess --bucket=nep-high-perf --sleep-per-step=0 --num-workers=32 --prefetch-factor=100 --epochs=7
2024-06-05 19:32:41.607 PDT
Listing started at time 1717641161.6069586
2024-06-05 19:32:41.750 PDT
ERROR:root:process dataflux-listing-proc.0 encountered error (4 retries left): 403 GET https://storage.googleapis.com/storage/v1/b/nep-high-perf/o?maxResults=5000&projection=noAcl&startOffset=&endOffset=&prettyPrint=false: 222564316065-compute@developer.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
2024-06-05 19:32:41.769 PDT
ERROR:root:process dataflux-listing-proc.0 encountered error (3 retries left): 403 GET https://storage.googleapis.com/storage/v1/b/nep-high-perf/o?maxResults=5000&projection=noAcl&startOffset=&endOffset=&prettyPrint=false: 222564316065-compute@developer.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
2024-06-05 19:32:41.798 PDT
ERROR:root:process dataflux-listing-proc.0 encountered error (2 retries left): 403 GET https://storage.googleapis.com/storage/v1/b/nep-high-perf/o?maxResults=5000&projection=noAcl&startOffset=&endOffset=&prettyPrint=false: 222564316065-compute@developer.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
2024-06-05 19:32:41.820 PDT
ERROR:root:process dataflux-listing-proc.0 encountered error (1 retries left): 403 GET https://storage.googleapis.com/storage/v1/b/nep-high-perf/o?maxResults=5000&projection=noAcl&startOffset=&endOffset=&prettyPrint=false: 222564316065-compute@developer.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
2024-06-05 19:32:41.840 PDT
ERROR:root:process dataflux-listing-proc.0 encountered error (0 retries left): 403 GET https://storage.googleapis.com/storage/v1/b/nep-high-perf/o?maxResults=5000&projection=noAcl&startOffset=&endOffset=&prettyPrint=false: 222564316065-compute@developer.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
2024-06-05 19:32:41.840 PDT
ERROR:root:process dataflux-listing-proc.0 is out of retries; exiting
2024-06-05 19:32:52.126 PDT
Listing discovered 0 objects in 10.518917083740234 seconds.
2024-06-05 19:32:52.127 PDT
Training started at time 1717641172.126963
2024-06-05 19:32:52.514 PDT
Epoch 0 took 0.3872370719909668 seconds to iterate over 0 objects and 0 bytes.
2024-06-05 19:32:52.579 PDT
Epoch 1 took 0.06535983085632324 seconds to iterate over 0 objects and 0 bytes.
2024-06-05 19:32:52.674 PDT
Epoch 2 took 0.0944814682006836 seconds to iterate over 0 objects and 0 bytes.
2024-06-05 19:32:52.745 PDT
Epoch 3 took 0.0713353157043457 seconds to iterate over 0 objects and 0 bytes.
2024-06-05 19:32:52.820 PDT
Epoch 4 took 0.07258820533752441 seconds to iterate over 0 objects and 0 bytes.
2024-06-05 19:32:52.886 PDT
Epoch 5 took 0.06670761108398438 seconds to iterate over 0 objects and 0 bytes.
2024-06-05 19:32:53.001 PDT
Epoch 6 took 0.11075401306152344 seconds to iterate over 0 objects and 0 bytes.
2024-06-05 19:32:53.001 PDT
All training (7 epochs) took 0.8742303848266602 seconds.
```