### PR TITLE
Fake update

### DIFF
--- a/dataflux_core/tests/fake_gcs.py
+++ b/dataflux_core/tests/fake_gcs.py
@@ -70,7 +70,7 @@ class FakeBlobWriter(object):
     def flush(self):
         pass
     def __enter__(self):
-        pass
+        return self
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 


### PR DESCRIPTION
Fake gcs update FakeBlobWriter 'enter' needs to return self for context managers

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR