### PR TITLE
Add user_agent module

### DIFF
--- a/dataflux_core/__init__.py
+++ b/dataflux_core/__init__.py
@@ -13,4 +13,4 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  """
-from . import fast_list, download
+from . import fast_list, download, user_agent

--- a/dataflux_core/tests/test_user_agent.py
+++ b/dataflux_core/tests/test_user_agent.py
@@ -1,0 +1,41 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+from dataflux_core import user_agent
+import unittest
+from google.cloud import storage
+from google.api_core.client_info import ClientInfo
+
+
+class UserAgentTest(unittest.TestCase):
+    def test_no_existing_info(self):
+        client = storage.Client()
+        user_agent.add_dataflux_user_agent(client)
+        self.assertIn("dataflux", client._connection._client_info.user_agent)
+
+    def test_no_existing_string(self):
+        client = storage.Client(client_info=ClientInfo())
+        user_agent.add_dataflux_user_agent(client)
+        self.assertIn("dataflux", client._connection._client_info.user_agent)
+
+    def test_with_existing_string(self):
+        existing_user_agent = "existing user agent"
+        client = storage.Client(client_info=ClientInfo(
+            user_agent=existing_user_agent))
+        user_agent.add_dataflux_user_agent(client)
+        self.assertIn("dataflux", client._connection._client_info.user_agent)
+        self.assertIn(existing_user_agent,
+                      client._connection._client_info.user_agent)

--- a/dataflux_core/user_agent.py
+++ b/dataflux_core/user_agent.py
@@ -1,0 +1,32 @@
+"""
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+from google.cloud import storage
+from google.api_core.client_info import ClientInfo
+
+user_agent_string = "dataflux/1.0"
+
+
+def add_dataflux_user_agent(storage_client: storage.Client):
+    if not storage_client._connection:
+        return
+    if not storage_client._connection._client_info:
+        storage_client._connection._client_info = ClientInfo(
+            user_agent=user_agent_string)
+    elif not storage_client._connection._client_info.user_agent:
+        storage_client._connection._client_info.user_agent = user_agent_string
+    elif user_agent_string not in storage_client._connection._client_info.user_agent:
+        storage_client._connection._client_info.user_agent += " " + user_agent_string


### PR DESCRIPTION
I'm not using the user_agent package yet in this PR, but I'll send a follow-up one where I use it. 

Unfortunately we have to use some internal class members from the underlying client libraries in order to update the user agent right now, but I've filed a feature request into https://github.com/googleapis/python-storage/issues/1327 to improve this. 

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR