### PR TITLE
Fix bug where list workers could be killed during retries

### DIFF
--- a/dataflux_core/tests/fake_gcs.py
+++ b/dataflux_core/tests/fake_gcs.py
@@ -31,6 +31,9 @@ from google.cloud.storage import _http
 class Bucket(object):
     """Bucket represents a bucket in GCS, containing objects."""
 
+    list_error = None
+    """If set, an error which is returned when calling list_blobs"""
+
     def __init__(self, name: str):
         if not name:
             raise Exception("bucket name must not be empty")

--- a/dataflux_core/tests/test_fast_list.py
+++ b/dataflux_core/tests/test_fast_list.py
@@ -221,6 +221,24 @@ class FastListTest(unittest.TestCase):
                 f"expected crashed process to be detected, but found no crashed processes"
             )
 
+    def test_check_crashed_processes_follow_retry_timeout(self):
+        """Tests that processes aren't considered to be crashed while waiting to retry API calls"""
+        controller = fast_list.ListingController(
+            10,
+            "",
+            "",
+            retry_config=fast_list.MODIFIED_RETRY.with_delay(maximum=90))
+        controller.inited.add("one")
+        controller.checkins["one"] = time.time() - 170
+        if controller.check_crashed_processes():
+            self.fail(
+                "expected no crahsed processes, but found crashed process")
+        controller.checkins["one"] = time.time() - 190
+        if not controller.check_crashed_processes():
+            self.fail(
+                "expected crashed process to be detected, but found no crashed processes"
+            )
+
     def test_cleanup_processes(self):
         """Tests that all processes are cleaned up at the end of execution."""
         controller = fast_list.ListingController(10, "", "", True)


### PR DESCRIPTION
This fixes an issue where list workers did not post on the heartbeat queue during retries, which could cause them to be seen as unresponsive if it took longer to complete a list call than the heartbeat deadline.

Now a heartbeat is posted on every retry, and the deadline before a list worker is killed is set to at least 2 * the maximum retry time.

I verified that the retry handler is being called in real errors by making it retry all errors and output a debug log, but I found that the retry class itself already adds its own debug log so I removed that for the PR.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR