### PR TITLE
Add test_iam_permissions to fake gcs to check permissions before running compose download

### DIFF
--- a/dataflux_core/tests/fake_gcs.py
+++ b/dataflux_core/tests/fake_gcs.py
@@ -72,12 +72,8 @@ class Bucket(object):
                                     self,
                                     storage_class=storage_class)
 
-    def test_iam_permissions(self, permission: any):
-        result = []
-        for p in permission:
-            if p in self.permissions:
-                result.append(p)
-        return result
+    def test_iam_permissions(self, permissions: any):
+        return [p for p in permissions if p in self.permissions]
 
 
 class FakeBlobWriter(object):

--- a/dataflux_core/tests/fake_gcs.py
+++ b/dataflux_core/tests/fake_gcs.py
@@ -36,6 +36,9 @@ class Bucket(object):
             raise Exception("bucket name must not be empty")
         self.name = name
         self.blobs: dict[str, Blob] = dict()
+        self.permissions: any = [
+            "storage.objects.create", "storage.objects.delete"
+        ]
 
     def list_blobs(
         self,
@@ -68,6 +71,13 @@ class Bucket(object):
                                     content,
                                     self,
                                     storage_class=storage_class)
+
+    def test_iam_permissions(self, permission: any):
+        result = []
+        for p in permission:
+            if p in self.permissions:
+                result.append(p)
+        return result
 
 
 class FakeBlobWriter(object):
@@ -151,3 +161,6 @@ class Client(object):
             if name in self.content:
                 self.buckets[name].content = self.content[name]
         return self.buckets[name]
+
+    def _set_perm(self, permissions: any, name: str):
+        self.buckets[name].permissions = permissions

--- a/dataflux_core/tests/fake_gcs.py
+++ b/dataflux_core/tests/fake_gcs.py
@@ -36,9 +36,7 @@ class Bucket(object):
             raise Exception("bucket name must not be empty")
         self.name = name
         self.blobs: dict[str, Blob] = dict()
-        self.permissions: any = [
-            "storage.objects.create", "storage.objects.delete"
-        ]
+        self.permissions: any = []
 
     def list_blobs(
         self,

--- a/dataflux_core/tests/test_fake_gcs.py
+++ b/dataflux_core/tests/test_fake_gcs.py
@@ -136,6 +136,24 @@ class FakeGCSTest(unittest.TestCase):
         blob = bucket.blob("test")
         self.assertIsInstance(blob.open("wb"), fake_gcs.FakeBlobWriter)
 
+    def test_permissions(self):
+        test_bucket = "test-bucket"
+        test_perm = ["test-perm-1", "test-perm-3"]
+        client = fake_gcs.Client()
+        bucket = client.bucket(test_bucket)
+        client._set_perm(["test-perm-1", "test-perm-2", "test-perm-3"],
+                         test_bucket)
+        got_perm = bucket.test_iam_permissions(test_perm)
+        self.assertEqual(got_perm, test_perm)
+
+    def test_no_permissions(self):
+        test_bucket = "test-bucket"
+        test_perm = ["test-perm-1", "test-perm-3"]
+        client = fake_gcs.Client()
+        bucket = client.bucket(test_bucket)
+        got_perm = bucket.test_iam_permissions(test_perm)
+        self.assertEqual(got_perm, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Dataflux pytorch dataset fail when user does not have required permissions to create and delete composed objects. 

"test_iam_permissions" is an in-built function used to verify permission of a client and will be used in dataflux_iterable_dataset and dataflux_mapstyle_dataset to verify client permissions.

Adding test_iam_permissions support to fake_gcs which will be used in test_dataflux_iterable_dataset and test_dataflux_mapstyle_dataset for unit tests. 

Related Issue: https://github.com/GoogleCloudPlatform/dataflux-pytorch/issues/58#issuecomment-2231552178

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR