### PR TITLE
Add blob.download_to_file to fake GCS

### DIFF
--- a/dataflux_core/tests/fake_gcs.py
+++ b/dataflux_core/tests/fake_gcs.py
@@ -134,6 +134,9 @@ class Blob(object):
     def download_as_bytes(self, retry=None):
         return self.content
 
+    def download_to_file(self, file_obj: io.IOBase) -> None:
+        file_obj.write(self.content)
+
     def open(self, mode: str, ignore_flush: bool = False):
         if mode == "rb":
             return io.BytesIO(self.content)

--- a/dataflux_core/tests/test_fake_gcs.py
+++ b/dataflux_core/tests/test_fake_gcs.py
@@ -154,6 +154,17 @@ class FakeGCSTest(unittest.TestCase):
         got_perm = bucket.test_iam_permissions(test_perm)
         self.assertEqual(got_perm, [])
 
+    def test_download_to_file(self):
+        bucket = fake_gcs.Client().bucket("test-bucket")
+        name = "obj1"
+        contents = b"aaaa"
+        bucket._add_file(name, contents)
+
+        stream = io.BytesIO()
+        bucket.blob(name).download_to_file(stream)
+        stream.seek(0)
+        self.assertEqual(stream.read(), contents)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This will support a PR I have pending for the dataflux-pytorch repo

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR