### PR TITLE
solve possible hang of fast list

### DIFF
--- a/dataflux_core/fast_list.py
+++ b/dataflux_core/fast_list.py
@@ -120,7 +120,7 @@ class ListWorker(object):
         self.client = client
         self.max_results = 5000
         self.splitter = None
-        self.default_alph = "a"
+        self.default_alph = "ab"
         self.skip_compose = skip_compose
         self.list_directory_objects = list_directory_objects
         self.prefix = prefix if prefix else ""


### PR DESCRIPTION
In ListWorker, default_alph is set to "a". However, if the parameter start_range in the split_range function happens to consist exclusively of the letter "a", such as "a" or "aa", and the other parameter end_range is "" or also consists exclusively of the letter "a", then the split_range function will hang. Therefore, default_alph must consist of at least two distinct characters, for example, "ab".