### PR TITLE
Reduce performance test timeout.

### DIFF
--- a/kokoro/hourly.cfg
+++ b/kokoro/hourly.cfg
@@ -51,7 +51,7 @@ env_vars {
 
 env_vars {
   key: "LIST_TIMEOUT"
-  value: "180"
+  value: "30"
 }
 
 env_vars {

--- a/kokoro/hourly.cfg
+++ b/kokoro/hourly.cfg
@@ -51,7 +51,7 @@ env_vars {
 
 env_vars {
   key: "LIST_TIMEOUT"
-  value: "10"
+  value: "180"
 }
 
 env_vars {

--- a/kokoro/nightly.cfg
+++ b/kokoro/nightly.cfg
@@ -51,7 +51,7 @@ env_vars {
 
 env_vars {
   key: "LIST_TIMEOUT"
-  value: "180"
+  value: "10"
 }
 
 env_vars {

--- a/kokoro/nightly.cfg
+++ b/kokoro/nightly.cfg
@@ -51,7 +51,7 @@ env_vars {
 
 env_vars {
   key: "LIST_TIMEOUT"
-  value: "10"
+  value: "180"
 }
 
 env_vars {

--- a/kokoro/presubmit.cfg
+++ b/kokoro/presubmit.cfg
@@ -51,7 +51,7 @@ env_vars {
 
 env_vars {
   key: "LIST_TIMEOUT"
-  value: "180"
+  value: "10"
 }
 
 env_vars {

--- a/kokoro/presubmit.cfg
+++ b/kokoro/presubmit.cfg
@@ -51,7 +51,7 @@ env_vars {
 
 env_vars {
   key: "LIST_TIMEOUT"
-  value: "10"
+  value: "180"
 }
 
 env_vars {


### PR DESCRIPTION
Performance tests should keep a relatively tight timeout to avoid negative performance creep. Presubmit and Nightly should be more aggressive, hourly can be more relaxed to reduce noise from transient errors unrelated to performance.

- [ ] Tests pass